### PR TITLE
Upgrade version numbers to 2.2

### DIFF
--- a/jsmessages/build.sbt
+++ b/jsmessages/build.sbt
@@ -6,9 +6,9 @@ organization := "com.github.julienrf"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.10.2"
 
-libraryDependencies += "play" %% "play" % "2.1.0"
+libraryDependencies += "com.typesafe.play" %% "play" % "2.2.0-RC1"
 
 publishTo <<= version {
   case v if v.trim.endsWith("SNAPSHOT") => Some(Resolver.file("Github Pages", Path.userHome / "sites" / "julienrf.github.com" / "repo-snapshots" asFile))

--- a/jsmessages/project/build.properties
+++ b/jsmessages/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.12.4


### PR DESCRIPTION
Now that RC of Play 2.2 have been release, maybe we can have a version compatible with it?

As far as I've seen they didn't broke anything, only bumps in version numbers are required.
