### PR TITLE
Play 2.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.8
-  - 2.12.1
+  - 2.11.12
+  - 2.12.8
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Take a look at the [Scala](/sample-scala) and [Java](/sample-java) samples to se
 Add a dependency on the following artifact:
 
 ```scala
-libraryDependencies += "org.julienrf" %% "play-jsmessages" % "4.0.0-SNAPSHOT"
+libraryDependencies += "org.julienrf" %% "play-jsmessages" % "4.0.0"
 ```
 
-The current 4.0.0-SNAPSHOT version is compatible with Play 2.7 and both Scala 2.11 and 2.12.
+The current 4.0.0 version is compatible with Play 2.7 and both Scala 2.11 and 2.12.
 
 Previous versions are available here:
  * [`3.0.0`](https://github.com/julienrf/play-jsmessages/tree/3.0.0) for play-2.6 ;
@@ -212,7 +212,7 @@ console.log(messagesFr('greeting', 'Julien')); // "Bonjour Julien!"
 Note: if you pass `undefined` as the language parameter, it will use the default messages.
 
 ## Changelog
-* 4.0.0-SNAPSHOT
+* 4.0.0
   - Play 2.7.x compatibility.
 
 * 3.0.0

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Take a look at the [Scala](/sample-scala) and [Java](/sample-java) samples to se
 Add a dependency on the following artifact:
 
 ```scala
-libraryDependencies += "org.julienrf" %% "play-jsmessages" % "3.0.0"
+libraryDependencies += "org.julienrf" %% "play-jsmessages" % "4.0.0-SNAPSHOT"
 ```
 
-The current 3.0.0 version is compatible with Play 2.6 and both Scala 2.11 and 2.12.
+The current 4.0.0-SNAPSHOT version is compatible with Play 2.7 and both Scala 2.11 and 2.12.
 
 Previous versions are available here:
+ * [`3.0.0`](https://github.com/julienrf/play-jsmessages/tree/3.0.0) for play-2.6 ;
  * [`2.1.0`](https://github.com/julienrf/play-jsmessages/tree/2.1.0) for play-2.5 ;
  * [`2.0.0`](https://github.com/julienrf/play-jsmessages/tree/2.0.0) for play-2.4 ;
  * [`1.6.2`](https://github.com/julienrf/play-jsmessages/tree/1.6.2) for play-2.3 ;
@@ -138,10 +139,11 @@ get one by mixing the `play.api.i18n.I18nSupport` trait in your controller.
 Or in Java:
 
 ```java
-import jsmessages.japi.Helper;
+@Inject
+private MessagesApi messagesApi;
 
-public Result messages() {
-    return ok(jsMessages.apply(Scala.Option("window.Messages"), Helper.messagesFromCurrentHttpContext()));
+public Result messages(Http.Request request) {
+    return ok(jsMessages.apply(Scala.Option("window.Messages"), this.messagesApi.preferred(request)));
 }
 ```
 
@@ -210,6 +212,9 @@ console.log(messagesFr('greeting', 'Julien')); // "Bonjour Julien!"
 Note: if you pass `undefined` as the language parameter, it will use the default messages.
 
 ## Changelog
+* 4.0.0-SNAPSHOT
+  - Play 2.7.x compatibility.
+
 * 3.0.0
   - Play 2.6.x compatibility. All tests moved to scalatest+play and dependency injection.
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ parallelExecution in Global := false
 val commonSettings = Seq(
   organization := "org.julienrf",
   version := "4.0.0-SNAPSHOT",
-  scalaVersion := "2.11.8"
+  scalaVersion := "2.11.12"
 )
 
 lazy val homePage = settingKey[File]("Path to the project home page")
@@ -12,7 +12,7 @@ lazy val jsmessages = project
   .settings(commonSettings: _*)
   .settings(
     name := "play-jsmessages",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := Seq("2.11.12", "2.12.8"),
     libraryDependencies ++= Seq(
       component("play")
     ),
@@ -50,8 +50,8 @@ lazy val jsmessages = project
 val sampleSettings = commonSettings ++ Seq(
   libraryDependencies ++= Seq(
     guice,
-    "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0" % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0" % Test
+    "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.0.1" % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.1" % Test
   ),
   resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 )
@@ -69,4 +69,3 @@ lazy val sampleJava = Project("sample-java", file("sample-java"))
 lazy val playJsmessages = project.in(file("."))
   .settings(commonSettings: _*)
   .aggregate(jsmessages, sampleScala, sampleJava)
-

--- a/jsmessages/src/main/scala/jsmessages/JsMessages.scala
+++ b/jsmessages/src/main/scala/jsmessages/JsMessages.scala
@@ -109,7 +109,7 @@ class JsMessages(allMessagesData: Map[String, Map[String, String]]) {
    * }}}
    *
    * Note: This implementation does not handle quotes escaping in patterns and subformats (see
-   * http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html)
+   * http://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html)
    *
    * @param namespace Optional JavaScript namespace to use to put the function definition. If not set, this
    *                  function will just generate a function. Otherwise it will generate a function and assign
@@ -151,7 +151,7 @@ class JsMessages(allMessagesData: Map[String, Map[String, String]]) {
    * Play default messages.
    *
    * Note: This implementation does not handle quotes escaping in patterns and subformats (see
-   * http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html)
+   * http://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html)
    *
    * @param namespace Optional JavaScript namespace to use to put the function definition. If not set, this
    *                  function will just generate a function. Otherwise it will generate a function and

--- a/jsmessages/src/main/scala/jsmessages/japi/Helper.java
+++ b/jsmessages/src/main/scala/jsmessages/japi/Helper.java
@@ -2,8 +2,9 @@ package jsmessages.japi;
 
 import play.mvc.Http;
 
-public class Helper {
+public final class Helper {
 
+    @Deprecated
     public static play.api.i18n.Messages messagesFromCurrentHttpContext() {
         return Http.Context.current().messages().asScala();
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")

--- a/sample-java/app/controllers/Application.java
+++ b/sample-java/app/controllers/Application.java
@@ -2,9 +2,10 @@ package controllers;
 
 import jsmessages.JsMessages;
 import jsmessages.JsMessagesFactory;
-import jsmessages.japi.Helper;
+import play.i18n.MessagesApi;
 import play.libs.Scala;
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -15,17 +16,20 @@ public class Application extends Controller {
 
     private final JsMessages jsMessages;
 
+    private final MessagesApi messagesApi;
+
     @Inject
-    public Application(JsMessagesFactory jsMessagesFactory) {
+    public Application(JsMessagesFactory jsMessagesFactory, MessagesApi messagesApi) {
         jsMessages = jsMessagesFactory.all();
+        this.messagesApi = messagesApi;
     }
 
     public Result index1() {
         return ok(views.html.index1.render());
     }
 
-    public Result jsMessages() {
-        return ok(jsMessages.apply(Scala.Option("window.Messages"), Helper.messagesFromCurrentHttpContext()));
+    public Result jsMessages(Http.Request request) {
+        return ok(jsMessages.apply(Scala.Option("window.Messages"), this.messagesApi.preferred(request).asScala()));
     }
 
 }

--- a/sample-java/conf/routes
+++ b/sample-java/conf/routes
@@ -2,7 +2,7 @@
 
 # Home page
 GET     /                           @controllers.Application.index1()
-GET     /messages.js                @controllers.Application.jsMessages()
+GET     /messages.js                @controllers.Application.jsMessages(request: Request)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               @controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
Updated the plugins, sbt version, Scala versions and the Java samples. Also deprecated the Helper class, since Play has deprecated the Http.Context class.