### PR TITLE
Play 2.9 and Scala 2 and 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Take a look at the [Scala](/sample-scala) and [Java](/sample-java) samples to se
 Add a dependency on the following artifact:
 
 ```scala
-libraryDependencies += "org.julienrf" %% "play-jsmessages" % "5.0.0"
+libraryDependencies += "org.julienrf" %% "play-jsmessages" % "6.0.0"
 ```
 
-The current 5.0.0 version is compatible with Play 2.8 and Scala 2.12 and 2.13.
+The current 6.0.0 version is compatible with Play 2.9 and Scala 2.13 and 3.3.
 
 Previous versions are available here:
+ * [`5.0.0`](https://github.com/julienrf/play-jsmessages/tree/4.0.0) for play-2.8 ;
  * [`4.0.0`](https://github.com/julienrf/play-jsmessages/tree/4.0.0) for play-2.7 ;
  * [`3.0.0`](https://github.com/julienrf/play-jsmessages/tree/3.0.0) for play-2.6 ;
  * [`2.1.0`](https://github.com/julienrf/play-jsmessages/tree/2.1.0) for play-2.5 ;
@@ -213,6 +214,9 @@ console.log(messagesFr('greeting', 'Julien')); // "Bonjour Julien!"
 Note: if you pass `undefined` as the language parameter, it will use the default messages.
 
 ## Changelog
+* 6.0.0
+  - Play 2.9.x compatibility.
+
 * 5.0.0
   - Play 2.8.x compatibility.
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ parallelExecution in Global := false
 
 val commonSettings = Seq(
   organization := "org.julienrf",
-  version := "5.0.0",
-  scalaVersion := "2.13.1"
+  version := "6.0.0",
+  scalaVersion := "2.13.12"
 )
 
 lazy val homePage = settingKey[File]("Path to the project home page")
@@ -12,10 +12,10 @@ lazy val jsmessages = project
   .settings(commonSettings: _*)
   .settings(
     name := "play-jsmessages",
-    crossScalaVersions := Seq("2.12.11", "2.13.1"),
+    crossScalaVersions := Seq("2.13.12", "3.3.1"),
     libraryDependencies ++= Seq(
       component("play"),
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1"
     ),
     publishMavenStyle := true,
     publishTo := {
@@ -50,10 +50,10 @@ lazy val jsmessages = project
 val sampleSettings = commonSettings ++ Seq(
   libraryDependencies ++= Seq(
     guice,
-    "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.1.2" % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
+    "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.2.5" % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0" % Test
   ),
-  resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+  //resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 )
 
 lazy val sampleScala = Project("sample-scala", file("sample-scala"))

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ parallelExecution in Global := false
 
 val commonSettings = Seq(
   organization := "org.julienrf",
-  version := "6.0.0",
+  version := "6.0.0-SNAPSHOT",
   scalaVersion := "2.13.12"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/sample-java/app/views/index1.scala.html
+++ b/sample-java/app/views/index1.scala.html
@@ -1,4 +1,4 @@
 @main {
-  <script type="text/javascript" src="@routes.Application.jsMessages()"></script>
+  <script type="text/javascript" src="@routes.Application.jsMessages"></script>
   @usage()
 }

--- a/sample-java/app/views/index1.scala.html
+++ b/sample-java/app/views/index1.scala.html
@@ -1,4 +1,4 @@
 @main {
-  <script type="text/javascript" src="@routes.Application.jsMessages"></script>
+  <script type="text/javascript" src="@routes.Application.jsMessages()"></script>
   @usage()
 }

--- a/sample-scala/app/controllers/Application.scala
+++ b/sample-scala/app/controllers/Application.scala
@@ -1,10 +1,9 @@
 package controllers
 
 import javax.inject.Inject
-
 import jsmessages.JsMessagesFactory
 import play.api.i18n.I18nSupport
-import play.api.mvc.{BaseController, ControllerComponents}
+import play.api.mvc.{AnyContent, BaseController, ControllerComponents, Request}
 
 class Application @Inject()(
                              jsMessagesFactory: JsMessagesFactory,
@@ -27,7 +26,7 @@ class Application @Inject()(
     Ok(views.html.index2())
   }
 
-  val jsMessages = Action { implicit request =>
+  val jsMessages = Action { implicit request: Request[AnyContent] =>
     Ok(messages(Some("window.Messages")))
   }
 
@@ -47,7 +46,7 @@ class Application @Inject()(
     Ok(views.js.all(messages))
   }
 
-  val jsMessagesTmpl = Action { implicit request =>
+  val jsMessagesTmpl = Action { implicit request: Request[AnyContent] =>
     Ok(views.js.messages(messages))
   }
 
@@ -77,7 +76,7 @@ class Application @Inject()(
     Ok(views.html.subset.subset())
   }
 
-  val subsetMessages = Action { implicit request =>
+  val subsetMessages = Action { implicit request: Request[AnyContent] =>
     Ok(messagesSubset(Some("window.Messages")))
   }
 
@@ -95,7 +94,7 @@ class Application @Inject()(
     Ok(views.html.filter.filter())
   }
 
-  val filterMessages = Action { implicit request =>
+  val filterMessages = Action { implicit request: Request[AnyContent] =>
     Ok(filteredMessages(Some("window.Messages")))
   }
 

--- a/sample-scala/app/views/all1.scala.html
+++ b/sample-scala/app/views/all1.scala.html
@@ -1,3 +1,3 @@
 @allMain {
-  <script type="text/javascript" src="@routes.Application.allJsMessages()"></script>
+  <script type="text/javascript" src="@routes.Application.allJsMessages"></script>
 }

--- a/sample-scala/app/views/all2.scala.html
+++ b/sample-scala/app/views/all2.scala.html
@@ -1,3 +1,3 @@
 @allMain {
-  <script src="@routes.Application.allJsMessagesTmpl()"></script>
+  <script src="@routes.Application.allJsMessagesTmpl"></script>
 }

--- a/sample-scala/app/views/cn.scala.html
+++ b/sample-scala/app/views/cn.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.allJsMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.allJsMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/en.scala.html
+++ b/sample-scala/app/views/en.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.allJsMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.allJsMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/enUS.scala.html
+++ b/sample-scala/app/views/enUS.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.allJsMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.allJsMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/filter/filter.scala.html
+++ b/sample-scala/app/views/filter/filter.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.filterMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.filterMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/filter/filterAll.scala.html
+++ b/sample-scala/app/views/filter/filterAll.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.filterAllMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.filterAllMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/fr.scala.html
+++ b/sample-scala/app/views/fr.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.allJsMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.allJsMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/index1.scala.html
+++ b/sample-scala/app/views/index1.scala.html
@@ -1,3 +1,3 @@
 @main {
-  <script type="text/javascript" src="@routes.Application.jsMessages()"></script>
+  <script type="text/javascript" src="@routes.Application.jsMessages"></script>
 }

--- a/sample-scala/app/views/index2.scala.html
+++ b/sample-scala/app/views/index2.scala.html
@@ -1,3 +1,3 @@
 @main {
-  <script src="@routes.Application.jsMessagesTmpl()"></script>
+  <script src="@routes.Application.jsMessagesTmpl"></script>
 }

--- a/sample-scala/app/views/noLang.scala.html
+++ b/sample-scala/app/views/noLang.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.allJsMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.allJsMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/subset/subset.scala.html
+++ b/sample-scala/app/views/subset/subset.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.subsetMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.subsetMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];

--- a/sample-scala/app/views/subset/subsetAll.scala.html
+++ b/sample-scala/app/views/subset/subsetAll.scala.html
@@ -8,7 +8,7 @@
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     </head>
     <body>
-        <script type="text/javascript" src="@routes.Application.subsetAllMessages()"></script>
+        <script type="text/javascript" src="@routes.Application.subsetAllMessages"></script>
         <script type="text/javascript">
           (function () {
             var tests = [];


### PR DESCRIPTION
- tested with Scala 2.13.12 and 3.3.1 / JDK 11 and 21
- `salaz-bintray` is commented out, tests worked without it. If needed it can be commented back in with protocol `https`
- I left the sbt version at `6.0.0-SNAPSHOT` for now