### PR TITLE
Play 3.1.0-M1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt ci-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
         cache: 'sbt'
+    - uses: sbt/setup-sbt@v1
     - name: Run tests
       run: sbt +test
       # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Add a dependency on the following artifact:
 libraryDependencies += "org.julienrf" %% "play-jsmessages" % "7.0.0"
 ```
 
-The current 7.0.0 version is compatible with Play 3.0 and Scala 2.13 and 3.3.
+The current 8.0.0-M1 version is compatible with Play 3.1-M1 and Scala 2.13 and 3.3.
 
 Previous versions are available here:
+ * [`7.0.0`](https://github.com/julienrf/play-jsmessages/tree/v7.0.0) for play-3.0 ;
  * [`6.0.0`](https://github.com/julienrf/play-jsmessages/tree/v6.0.0) for play-2.9 ;
  * [`5.0.0`](https://github.com/julienrf/play-jsmessages/tree/v5.0.0) for play-2.8 ;
  * [`4.0.0`](https://github.com/julienrf/play-jsmessages/tree/v4.0.0) for play-2.7 ;

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val jsmessages = project
 val sampleSettings = commonSettings ++ Seq(
   libraryDependencies ++= Seq(
     guice,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test
+    "org.scalatestplus.play" %% "scalatestplus-play" % "8.0.0-M1" % Test
   ),
   publish / skip := true,
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ parallelExecution in Global := false
 
 val commonSettings = Seq(
   organization := "org.julienrf",
-  scalaVersion := "2.13.12"
+  scalaVersion := "2.13.16"
 )
 
 lazy val jsmessages = project
   .settings(commonSettings: _*)
   .settings(
     name := "play-jsmessages",
-    crossScalaVersions := Seq("2.13.12", "3.3.1"),
+    crossScalaVersions := Seq("2.13.16", "3.3.6"),
     libraryDependencies ++= Seq(
       component("play"),
     ),

--- a/jsmessages/src/main/scala/jsmessages/JsMessagesFactory.scala
+++ b/jsmessages/src/main/scala/jsmessages/JsMessagesFactory.scala
@@ -1,6 +1,6 @@
 package jsmessages
 
-import javax.inject.{Inject, Singleton}
+import jakarta.inject.{Inject, Singleton}
 
 import play.api.i18n.MessagesApi
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.1.0-M1")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")

--- a/sample-java/app/controllers/Application.java
+++ b/sample-java/app/controllers/Application.java
@@ -8,8 +8,8 @@ import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class Application extends Controller {

--- a/sample-scala/app/controllers/Application.scala
+++ b/sample-scala/app/controllers/Application.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 import jsmessages.JsMessagesFactory
 import play.api.i18n.I18nSupport
 import play.api.mvc.{AnyContent, BaseController, ControllerComponents, Request}


### PR DESCRIPTION
Support Play! framework 3.1.0-M1, which has been released 5 months ago.

**Drops Java 11 support**

There is no indication on when the final release will be ready, but many libs have taken this one.